### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SwiftKitten is a Swift autocompleter for Sublime Text, via the adorable 
 [SourceKitten](https://github.com/jpsim/SourceKitten.git) framework.
-Faster than XCode !
+Faster than Xcode !
 
 
 ![](demo.gif)


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/
Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
