### PR TITLE
Fix compilerargs format on sourcekitten arguments

### DIFF
--- a/SwiftKitten.py
+++ b/SwiftKitten.py
@@ -292,7 +292,7 @@ class SwiftKittenEventListener(sublime_plugin.EventListener):
     def get_completion_cmd(self, view, text, offset):
         """Get completion command.
         """
-        cmd = "{sourcekitten_binary} complete --text {text} --offset {offset} --compilerargs -- {compilerargs}"
+        cmd = "{sourcekitten_binary} complete --text {text} --offset {offset} -- {compilerargs}"
         sourcekitten_binary = self.get_settings(view,
             "sourcekitten_binary", "sourcekitten")
         compilerargs = self.get_compilerargs(view)
@@ -300,7 +300,7 @@ class SwiftKittenEventListener(sublime_plugin.EventListener):
             sourcekitten_binary=sourcekitten_binary,
             text=shlex.quote(text),
             offset=offset,
-            compilerargs=shlex.quote(compilerargs)
+            compilerargs=compilerargs
         )
 
 


### PR DESCRIPTION
Following from https://github.com/johncsnyder/SwiftKitten/issues/7
